### PR TITLE
[dependencies][CVE-2024-50379][CVE-2025-24813] upgrade tomcat 10.1.39

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
 
     <xbean.version>4.25</xbean.version>
     <owb.version>2.0.27</owb.version>
-    <tomcat.version>10.1.33</tomcat.version>
+    <tomcat.version>10.1.39</tomcat.version>
     <johnzon.version>1.2.21</johnzon.version>
 
     <!-- for quarkus only -->


### PR DESCRIPTION
Mise à jour de la version de tomcat en 10.1.39 pour patcher les CVE-2024-50379 et CVE-2025-24813